### PR TITLE
moving the get notifications request after the notification creation …

### DIFF
--- a/src/gatling/simulations/uk/gov/hmcts/paybubble/simulation/Refunds_API.scala
+++ b/src/gatling/simulations/uk/gov/hmcts/paybubble/simulation/Refunds_API.scala
@@ -163,13 +163,15 @@ class Refunds_API extends Simulation {
         .exec(S2SHelper.RefundsS2SAuthToken)
         .exec(IDAMHelper.refundsGetIdamToken)
         .exec(RefundsV2.submitRefund)
-        .exec(Notifications.getNotifications)
         .exec(Notifications.notificationsDocPreview)
         .exec(Notifications.notificationsEmail)
         .exec(Notifications.notificationsLetter)
+        .exec(Notifications.getNotifications)
         .exec(RefundsV2.cancelRefund)
         .exec(RefundsV2.deleteRefund)
     }
+
+
 
 
 


### PR DESCRIPTION

### Change description ###

Minor change to move the get notifications request to after the creation of notifications in the notifications simulation.  This should resolve the exceptions seen during the testing.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
